### PR TITLE
 soong: add TARGET_HAS_MEMFD_BACKPORT conditional

### DIFF
--- a/soong/Android.bp
+++ b/soong/Android.bp
@@ -680,3 +680,19 @@ cc_genrule {
     srcs: [":linker"],
     out: ["linker.flags"],
 }
+
+soong_config_module_type {
+    name: "has_memfd_backport",
+    module_type: "cc_defaults",
+    config_namespace: "lineageGlobalVars",
+    bool_variables: ["has_memfd_backport"],
+    properties: ["cppflags"],
+}
+has_memfd_backport {
+    name: "has_memfd_backport_defaults",
+    soong_config_variables: {
+        has_memfd_backport: {
+            cppflags: ["-DHAS_MEMFD_BACKPORT"],
+        },
+    },
+}


### PR DESCRIPTION
taken from https://review.lineageos.org/c/LineageOS/android_vendor_lineage/+/289841/1/build/soong/Android.bp#237